### PR TITLE
Add todo keyword to typst.toml

### DIFF
--- a/typst.toml
+++ b/typst.toml
@@ -6,7 +6,7 @@ authors = ["Nathan Jessurun"]
 license = "Unlicense"
 description = "Helpful functions for content positioning and margin comments/notes"
 repository = "https://github.com/ntjess/typst-drafting"
-keywords = ["comments", "notes", "margins", "positioning", "layout", "ruler"]
+keywords = ["comments", "notes", "margins", "positioning", "layout", "ruler", "todo"]
 categories = ["layout", "utility"]
 compiler = "0.11.0"
 


### PR DESCRIPTION
Currently, when the [searching for "todo"](https://typst.app/universe/search?q=todo) in the packages universe, this library does not show up. As it is similar to the todonotes library in Latex, people coming from Latex will probably search for "todo" when they search for the functionality of the drafting package.