### PR TITLE
Make auto put the note on the side it is closest to

### DIFF
--- a/drafting.typ
+++ b/drafting.typ
@@ -11,7 +11,8 @@
 /// - `rect` (function): Function to use for drawing the margin note's border. This
 ///   function must accept positional `content` and keyword `width` arguments.
 /// - `side` (side): Which side of the page to place the margin note on. Must be `left`
-///   or `right`
+///   `right` or `auto`. When set to `auto`, the note will be placed on the
+///   side that it is closest to
 /// - `hidden` (bool): Whether to hide the margin note. This is useful for temporarily
 ///   disabling margin notes without removing them from the code
 #let margin-note-defaults = state(
@@ -398,9 +399,9 @@
       return
     }
 
+    // If properties.side is auto, place out if this note in the margin it is closest to
     if properties.side == auto {
-      let (r, l) = (properties.margin-right, properties.margin-left)
-      properties.side = if calc.max(r, l) == r { right } else { left }
+      properties.side = if pos.x > properties.page-width/2 {right} else {left}
     }
     for k in ("margin-right", "margin-left", "page-width") {
       if k not in properties or properties.at(k) == none {


### PR DESCRIPTION
In 2 column mode, having the notes always on one side is quite problematic as it makes some notes span across the columns

![image](https://github.com/user-attachments/assets/8f643b87-9053-4d8f-8f53-8889b7710f8f)

This changes the behaviour of `auto` for the side positioning from just picking the largest margin to picking the margin which it is closest to

![image](https://github.com/user-attachments/assets/5e45a26f-7459-42d2-b2a5-7592823e8a37)

Not sure how you feel about breaking changes here, when I saw `auto` for the side, I figured this is what it would do, but I'm also open to having `side: "closest"`