### PR TITLE
Update README.md with best practice

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,10 @@ Even deeper customization is possible by overriding the default `rect`:
 #import "@preview/colorful-boxes:1.1.0": stickybox
 
 #let default-rect(stroke: none, fill: none, width: 0pt, content) = {
-  set text(0.9em)
-  stickybox(rotation: 30deg, width: width/1.5, content)
+  stickybox(rotation: 30deg, width: width/1.5)[
+    #set text(0.9em)
+    #content
+  ]
 }
 #set-margin-note-defaults(rect: default-rect, stroke: none, side: right)
 


### PR DESCRIPTION
Using a `#set` rule within a custom `rect`, should be constructed the proposed way.
The reason is that https://github.com/ntjess/typst-drafting/blob/a2ffad113138ff1a47002df535f832d3646a520c/drafting.typ#L470 is only triggered if the custom `rect` function returns an element, which only happens when users write them like in the proposed change.
Of course, this code path is actually only triggered when using `#inline-note(par-break: false, rect: default-rect)[My inline note]` or `#margin-note(rect: default-rect)[highlighted sentence, unless default-rect is constructed the wrong way][sentence in margin note]` (and maybe `#note-outline`, didn't test it yet).
This mainly happens when using the same custom `rect` in all cases (like in #10 - I'll show my final use-case there).

Since the PR is actually less relevant for the shown example (which has no `.fill` field), you can certainly reject this, but I would suggest some other documentation then.