### PR TITLE
Don't number `note-outline` heading

### DIFF
--- a/drafting.typ
+++ b/drafting.typ
@@ -395,8 +395,14 @@
   level: 1,
   /// Spacing between outline elements  -> relative
   row-gutter: 10pt,
+  /// Whether the outline heading should receive a number
+  number-heading: false,
 ) = context {
-  heading(level: level, title)
+  heading(
+    level: level,
+    numbering: if number-heading { none } else { heading.numbering },
+    title,
+  )
 
   let notes = query(selector(<margin-note>).or(<inline-note>)).map(note => {
     show: box // do not break entries across pages


### PR DESCRIPTION
This changes the default behavior of `note-outline` so that it doesn't number the heading it generates.  The heading shouldn't be numbered by default because typically this notes section isn't a part of the final published document and would change the numbers of sections that are, which can cause mistakes, e.g. writing the literal "Section 6" instead of "Section 5".

Closes https://github.com/ntjess/typst-drafting/issues/36