### PR TITLE
Fix `_get-margins`

### DIFF
--- a/drafting.typ
+++ b/drafting.typ
@@ -260,12 +260,12 @@
     margin.left = page.margin
     margin.right = page.margin
   } else {
-    if "right" in page.margin.keys() {
-      margin.right = page.margin.right
-      margin.left = page.margin.left
-    } else if "inside" in page.margin.keys() {
-      margin.inside = page.margin.inside
-      margin.outside = page.margin.outside
+    if "left" in page.margin.keys() or "right" in page.margin.keys() {
+      margin.left = page.margin.at("left", default: auto)
+      margin.right = page.margin.at("right", default: auto)
+    } else if "inside" in page.margin.keys() or "outside" in page.margin.keys() {
+      margin.inside = page.margin.at("inside", default: auto)
+      margin.outside = page.margin.at("outside", default: auto)
     }
   }
 


### PR DESCRIPTION
`_get-margins` does not build the margin struct correctly. It fails if only `margin.left` is specified for example.

This PR fixes this by
1. checke whether `left` OR `right` is set to determine whether to set `left` and `right` or `inside` and `outside`
2. filling unspecified values with `auto`

I also noticed that the files are not formatted. If you want I can open a separate PR adding a fmt pipeline and formatting everything once to begin with. 